### PR TITLE
Feature: multiple request masks

### DIFF
--- a/tcp-mocker-core/pom.xml
+++ b/tcp-mocker-core/pom.xml
@@ -11,6 +11,7 @@
     <name>payworks/labs/tcp-mocker/core</name>
 
     <dependencies>
+        <!-- TODO: core must not be dependant on model/recordings -->
         <dependency>
             <groupId>io.payworks.labs.tcpmocker</groupId>
             <artifactId>tcp-mocker-model</artifactId>

--- a/tcp-mocker-core/src/main/java/io/payworks/labs/tcpmocker/datahandler/RecordingDataHandler.java
+++ b/tcp-mocker-core/src/main/java/io/payworks/labs/tcpmocker/datahandler/RecordingDataHandler.java
@@ -5,8 +5,10 @@ import io.payworks.labs.tcpmocker.model.RecordingsRepository;
 
 import java.util.Optional;
 
+// TODO: extract recordings from core/model to separate module
 public class RecordingDataHandler implements DataHandler {
 
+    // TODO: create interface to allow various implementations of storage
     private final RecordingsRepository repository;
 
     private final DataHandler delegate;

--- a/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/DataHandlerFactory.java
+++ b/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/DataHandlerFactory.java
@@ -1,0 +1,49 @@
+package io.payworks.labs.tcpmocker.support;
+
+import io.payworks.labs.tcpmocker.datahandler.*;
+import io.payworks.labs.tcpmocker.order.Ordered;
+import io.payworks.labs.tcpmocker.support.datahandlermodel.DataHandlerModel;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class DataHandlerFactory {
+
+    public DataHandler createDataHandler(final DataHandlerModel dataHandlerModel) {
+        final DataHandlerType dataHandlerType = getDataHandlerType(dataHandlerModel);
+        final String responseData = dataHandlerModel.getResponse().getData();
+        final List<DataHandlerModel.Request> requestsToMatch = dataHandlerModel.getRequestList();
+        final int order = getOrder(dataHandlerModel);
+
+        final List<DataHandler> dataHandlers = requestsToMatch.stream().map(DataHandlerModel.Request::getMatches)
+                .map(hexRegex -> createHexRegexDataHandler(dataHandlerType, hexRegex, responseData))
+                .collect(Collectors.toList());
+
+        return new OrderedDataHandler(order, new CompositeDataHandler(dataHandlers));
+    }
+
+    public HexRegexDataHandler createHexRegexDataHandler(final DataHandlerType dataHandlerType,
+                                                         final String hexRegex,
+                                                         final String responseData) {
+        switch (dataHandlerType) {
+            case DYNAMIC_HEX_REGEX:
+                return new DynamicHexRegexDataHandler(hexRegex, responseData);
+
+            case STATIC_HEX_REGEX:
+                return new StaticHexRegexDataHandler(hexRegex, responseData);
+
+            default:
+                throw new UnsupportedOperationException(String.format("Unknown DataHandler Type: %s", dataHandlerType));
+        }
+    }
+
+    private static int getOrder(final DataHandlerModel dataHandlerModel) {
+        final Integer order = dataHandlerModel.getOrder();
+        return order == null ? Ordered.DEFAULT_ORDER : order;
+    }
+
+    private static DataHandlerType getDataHandlerType(final DataHandlerModel dataHandlerModel) {
+        final DataHandlerType handlerType = dataHandlerModel.getHandlerType();
+        return handlerType == null ? DataHandlerType.STATIC_HEX_REGEX : handlerType;
+    }
+}

--- a/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/datahandlermodel/DataHandlerModel.java
+++ b/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/datahandlermodel/DataHandlerModel.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import io.payworks.labs.tcpmocker.datahandler.DataHandlerType;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class DataHandlerModel {
 
@@ -93,17 +93,17 @@ public class DataHandlerModel {
 
     private DataHandlerType handlerType;
     private Integer order;
-    private Request request;
+    private List<Request> requestList;
     private Response response;
 
     @JsonCreator
     public DataHandlerModel(@JsonProperty("handlerType") DataHandlerType handlerType,
                             @JsonProperty("order") Integer order,
-                            @JsonProperty("request") Request request,
+                            @JsonProperty("request") List<Request> requestList,
                             @JsonProperty("response") Response response) {
         this.handlerType = handlerType;
         this.order = order;
-        this.request = request;
+        this.requestList = requestList;
         this.response = response;
     }
 
@@ -118,8 +118,13 @@ public class DataHandlerModel {
     }
 
     @JsonProperty("request")
+    public List<Request> getRequestList() {
+        return ImmutableList.copyOf(requestList);
+    }
+
+    @JsonIgnore
     public Request getRequest() {
-        return request;
+        return Iterables.getFirst(requestList, null);
     }
 
     @JsonProperty("response")
@@ -134,13 +139,13 @@ public class DataHandlerModel {
         DataHandlerModel that = (DataHandlerModel) o;
         return handlerType == that.handlerType &&
                 Objects.equals(order, that.order) &&
-                Objects.equals(request, that.request) &&
+                Objects.equals(requestList, that.requestList) &&
                 Objects.equals(response, that.response);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(handlerType, order, request, response);
+        return Objects.hash(handlerType, order, requestList, response);
     }
 
     @Override
@@ -148,7 +153,7 @@ public class DataHandlerModel {
         return MoreObjects.toStringHelper(this)
                 .add("handlerType", handlerType)
                 .add("order", order)
-                .add("request", request)
+                .add("requestList", requestList)
                 .add("response", response)
                 .toString();
     }

--- a/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/datahandlermodel/DataHandlerModel.java
+++ b/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/datahandlermodel/DataHandlerModel.java
@@ -1,6 +1,7 @@
 package io.payworks.labs.tcpmocker.support.datahandlermodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -22,6 +23,7 @@ public class DataHandlerModel {
         }
 
         @JsonProperty("matches")
+        @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
         public List<String> getMatchesList() {
             return ImmutableList.copyOf(matchesList);
         }
@@ -61,6 +63,7 @@ public class DataHandlerModel {
         }
 
         @JsonProperty("data")
+        @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
         public List<String> getDataList() {
             return ImmutableList.copyOf(dataList);
         }
@@ -118,6 +121,7 @@ public class DataHandlerModel {
     }
 
     @JsonProperty("request")
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
     public List<Request> getRequestList() {
         return ImmutableList.copyOf(requestList);
     }

--- a/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/datahandlermodel/DataHandlerModelReader.java
+++ b/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/datahandlermodel/DataHandlerModelReader.java
@@ -1,5 +1,7 @@
 package io.payworks.labs.tcpmocker.support.datahandlermodel;
 
+import io.payworks.labs.tcpmocker.support.resource.ResourceUtils;
+
 import java.io.InputStream;
 import java.net.URL;
 
@@ -8,4 +10,8 @@ public interface DataHandlerModelReader {
     DataHandlerModel read(InputStream src);
 
     DataHandlerModel read(URL src);
+
+    default DataHandlerModel urlRead(final String src) {
+        return read(ResourceUtils.toResourceUrl(src));
+    }
 }

--- a/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/json/JsonMappingReader.java
+++ b/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/json/JsonMappingReader.java
@@ -1,6 +1,5 @@
 package io.payworks.labs.tcpmocker.support.json;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.payworks.labs.tcpmocker.support.datahandlermodel.DataHandlerModel;
 import io.payworks.labs.tcpmocker.support.datahandlermodel.DataHandlerModelReader;
@@ -11,8 +10,7 @@ import java.net.URL;
 
 public class JsonMappingReader implements DataHandlerModelReader {
 
-    private final ObjectMapper objectMapper = new ObjectMapper()
-            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public DataHandlerModel read(final InputStream src) {
         try {

--- a/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/yml/YamlMappingReader.java
+++ b/tcp-mocker-support/src/main/java/io/payworks/labs/tcpmocker/support/yml/YamlMappingReader.java
@@ -1,6 +1,5 @@
 package io.payworks.labs.tcpmocker.support.yml;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.payworks.labs.tcpmocker.support.datahandlermodel.DataHandlerModel;
@@ -13,8 +12,7 @@ import java.net.URL;
 
 public class YamlMappingReader implements DataHandlerModelReader {
 
-    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory())
-            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
 
     public DataHandlerModel read(final InputStream src) {
         try {

--- a/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/support/json/JsonMappingReaderTest.java
+++ b/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/support/json/JsonMappingReaderTest.java
@@ -37,7 +37,7 @@ public class JsonMappingReaderTest {
         assertThat(dataHandlerModel, notNullValue());
 
         assertThat(dataHandlerModel.getRequestList().stream().map(DataHandlerModel.Request::getMatches).collect(Collectors.toList()), contains("0200\\d{10}4F2F0F90000030", "0201\\d{10}4F2F0F90000030"));
-        assertThat(dataHandlerModel.getResponse().getData(), equalToIgnoringCase("ad122e1b75356c6fdf3e9c3076a80da6"));
+        assertThat(dataHandlerModel.getResponse().getData(), equalToIgnoringCase("ad122e1b75356c6fdf3e9c3076a80da611"));
     }
 
 }

--- a/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/support/json/JsonMappingReaderTest.java
+++ b/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/support/json/JsonMappingReaderTest.java
@@ -3,28 +3,19 @@ package io.payworks.labs.tcpmocker.support.json;
 import io.payworks.labs.tcpmocker.support.datahandlermodel.DataHandlerModel;
 import org.testng.annotations.Test;
 
-import java.net.URL;
+import java.util.stream.Collectors;
 
-import static io.payworks.labs.tcpmocker.support.resource.ResourceUtils.toResourceUrl;
-import static io.payworks.labs.tcpmocker.test.TcpMappingsRegistry.TEST_DEFAULT_JSON_MAPPING_1;
-import static io.payworks.labs.tcpmocker.test.TcpMappingsRegistry.TEST_LIST_JSON_MAPPING_1;
+import static io.payworks.labs.tcpmocker.test.TcpMappingsRegistry.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToIgnoringCase;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 public class JsonMappingReaderTest {
-
-    private static final URL TEST_DEFAULT_JSON_MAPPING_1_URL =
-            toResourceUrl(TEST_DEFAULT_JSON_MAPPING_1);
-
-    private static final URL TEST_LIST_JSON_MAPPING_1_URL =
-            toResourceUrl(TEST_LIST_JSON_MAPPING_1);
 
     private final JsonMappingReader mappingReader = new JsonMappingReader();
 
     @Test
     public void readTestDefaultJsonMapping() {
-        final DataHandlerModel dataHandlerModel = mappingReader.read(TEST_DEFAULT_JSON_MAPPING_1_URL);
+        final DataHandlerModel dataHandlerModel = mappingReader.urlRead(TEST_DEFAULT_JSON_MAPPING_1);
         assertThat(dataHandlerModel, notNullValue());
 
         assertThat(dataHandlerModel.getRequest().getMatches(), equalToIgnoringCase("0200\\d{10}4F2F0F90000030"));
@@ -33,10 +24,19 @@ public class JsonMappingReaderTest {
 
     @Test
     public void readTestListJsonMapping() {
-        final DataHandlerModel dataHandlerModel = mappingReader.read(TEST_LIST_JSON_MAPPING_1_URL);
+        final DataHandlerModel dataHandlerModel = mappingReader.urlRead(TEST_LIST_JSON_MAPPING_1);
         assertThat(dataHandlerModel, notNullValue());
 
         assertThat(dataHandlerModel.getRequest().getMatches(), equalToIgnoringCase("0200\\d{10}4F2F0F90000030"));
+        assertThat(dataHandlerModel.getResponse().getData(), equalToIgnoringCase("ad122e1b75356c6fdf3e9c3076a80da6"));
+    }
+
+    @Test
+    public void readTestMultiRequestJsonMapping() {
+        final DataHandlerModel dataHandlerModel = mappingReader.urlRead(TEST_MULTIREQUEST_JSON_MAPPING_1);
+        assertThat(dataHandlerModel, notNullValue());
+
+        assertThat(dataHandlerModel.getRequestList().stream().map(DataHandlerModel.Request::getMatches).collect(Collectors.toList()), contains("0200\\d{10}4F2F0F90000030", "0201\\d{10}4F2F0F90000030"));
         assertThat(dataHandlerModel.getResponse().getData(), equalToIgnoringCase("ad122e1b75356c6fdf3e9c3076a80da6"));
     }
 

--- a/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/support/yaml/YamlMappingReaderTest.java
+++ b/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/support/yaml/YamlMappingReaderTest.java
@@ -38,7 +38,7 @@ public class YamlMappingReaderTest {
         assertThat(dataHandlerModel, notNullValue());
 
         assertThat(dataHandlerModel.getRequestList().stream().map(DataHandlerModel.Request::getMatches).collect(Collectors.toList()), contains("0200\\d{10}4F2F0F90000030", "0201\\d{10}4F2F0F90000030"));
-        assertThat(dataHandlerModel.getResponse().getData(), equalToIgnoringCase("ad122e1b75356c6fdf3e9c3076a80da6"));
+        assertThat(dataHandlerModel.getResponse().getData(), equalToIgnoringCase("ad122e1b75356c6fdf3e9c3076a80da612"));
     }
 
 }

--- a/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/support/yaml/YamlMappingReaderTest.java
+++ b/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/support/yaml/YamlMappingReaderTest.java
@@ -4,28 +4,19 @@ import io.payworks.labs.tcpmocker.support.datahandlermodel.DataHandlerModel;
 import io.payworks.labs.tcpmocker.support.yml.YamlMappingReader;
 import org.testng.annotations.Test;
 
-import java.net.URL;
+import java.util.stream.Collectors;
 
-import static io.payworks.labs.tcpmocker.support.resource.ResourceUtils.toResourceUrl;
-import static io.payworks.labs.tcpmocker.test.TcpMappingsRegistry.TEST_DEFAULT_YAML_MAPPING_1;
-import static io.payworks.labs.tcpmocker.test.TcpMappingsRegistry.TEST_LIST_YAML_MAPPING_1;
+import static io.payworks.labs.tcpmocker.test.TcpMappingsRegistry.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToIgnoringCase;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 public class YamlMappingReaderTest {
-
-    private static final URL TEST_DEFAULT_YAML_MAPPING =
-            toResourceUrl(TEST_DEFAULT_YAML_MAPPING_1);
-
-    private static final URL TEST_LIST_YAML_MAPPING =
-            toResourceUrl(TEST_LIST_YAML_MAPPING_1);
 
     private final YamlMappingReader mappingReader = new YamlMappingReader();
 
     @Test
     public void testReadDefaultYamlMapping() {
-        final DataHandlerModel dataHandlerModel = mappingReader.read(TEST_DEFAULT_YAML_MAPPING);
+        final DataHandlerModel dataHandlerModel = mappingReader.urlRead(TEST_DEFAULT_YAML_MAPPING_1);
         assertThat(dataHandlerModel, notNullValue());
 
         assertThat(dataHandlerModel.getRequest().getMatches(), equalToIgnoringCase("0200\\d{10}4F2F0F90000030"));
@@ -34,10 +25,19 @@ public class YamlMappingReaderTest {
 
     @Test
     public void readTestListYamlMapping() {
-        final DataHandlerModel dataHandlerModel = mappingReader.read(TEST_LIST_YAML_MAPPING);
+        final DataHandlerModel dataHandlerModel = mappingReader.urlRead(TEST_LIST_YAML_MAPPING_1);
         assertThat(dataHandlerModel, notNullValue());
 
         assertThat(dataHandlerModel.getRequest().getMatches(), equalToIgnoringCase("0200\\d{10}4F2F0F90000030"));
+        assertThat(dataHandlerModel.getResponse().getData(), equalToIgnoringCase("ad122e1b75356c6fdf3e9c3076a80da6"));
+    }
+
+    @Test
+    public void readTestMultiRequestYamlMapping() {
+        final DataHandlerModel dataHandlerModel = mappingReader.urlRead(TEST_MULTIREQUEST_YAML_MAPPING_1);
+        assertThat(dataHandlerModel, notNullValue());
+
+        assertThat(dataHandlerModel.getRequestList().stream().map(DataHandlerModel.Request::getMatches).collect(Collectors.toList()), contains("0200\\d{10}4F2F0F90000030", "0201\\d{10}4F2F0F90000030"));
         assertThat(dataHandlerModel.getResponse().getData(), equalToIgnoringCase("ad122e1b75356c6fdf3e9c3076a80da6"));
     }
 

--- a/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/test/TcpMappingsRegistry.java
+++ b/tcp-mocker-support/src/test/java/io/payworks/labs/tcpmocker/test/TcpMappingsRegistry.java
@@ -19,6 +19,9 @@ public final class TcpMappingsRegistry {
     public static final String TEST_ORDERED_JSON_MAPPING_1 = filePath("/test-ordered-json-mapping1.json");
     public static final String TEST_ORDERED_JSON_MAPPING_2 = filePath("/test-ordered-json-mapping2.json");
     public static final String TEST_ORDERED_JSON_MAPPING_3 = filePath("/test-ordered-json-mapping3.json");
+    public static final String TEST_MULTIREQUEST_JSON_MAPPING_1 = filePath("/test-multirequest-json-mapping1.json");
+    public static final String TEST_MULTIREQUEST_YAML_MAPPING_1 = filePath("/test-multirequest-yaml-mapping1.yml");
+
 
     private TcpMappingsRegistry() {
     }

--- a/tcp-mocker-support/src/test/resources/tcp-mappings/test-multirequest-json-mapping1.json
+++ b/tcp-mocker-support/src/test/resources/tcp-mappings/test-multirequest-json-mapping1.json
@@ -1,0 +1,13 @@
+{
+  "request": [
+    {
+      "matches": "0200\\d{10}4F2F0F90000030"
+    },
+    {
+      "matches": "0201\\d{10}4F2F0F90000030"
+    }
+  ],
+  "response": {
+    "data": "ad122e1b75356c6fdf3e9c3076a80da6"
+  }
+}

--- a/tcp-mocker-support/src/test/resources/tcp-mappings/test-multirequest-json-mapping1.json
+++ b/tcp-mocker-support/src/test/resources/tcp-mappings/test-multirequest-json-mapping1.json
@@ -8,6 +8,6 @@
     }
   ],
   "response": {
-    "data": "ad122e1b75356c6fdf3e9c3076a80da6"
+    "data": "ad122e1b75356c6fdf3e9c3076a80da611"
   }
 }

--- a/tcp-mocker-support/src/test/resources/tcp-mappings/test-multirequest-yaml-mapping1.yml
+++ b/tcp-mocker-support/src/test/resources/tcp-mappings/test-multirequest-yaml-mapping1.yml
@@ -1,4 +1,3 @@
-# https://stackoverflow.com/questions/3790454/in-yaml-how-do-i-break-a-string-over-multiple-lines
 request:
   - matches:
       - 0200
@@ -9,4 +8,4 @@ request:
       - \d{10}
       - 4F2F0F90000030
 response:
-  data: ad122e1b75356c6fdf3e9c3076a80da6
+  data: ad122e1b75356c6fdf3e9c3076a80da612

--- a/tcp-mocker-support/src/test/resources/tcp-mappings/test-multirequest-yaml-mapping1.yml
+++ b/tcp-mocker-support/src/test/resources/tcp-mappings/test-multirequest-yaml-mapping1.yml
@@ -1,0 +1,12 @@
+# https://stackoverflow.com/questions/3790454/in-yaml-how-do-i-break-a-string-over-multiple-lines
+request:
+  - matches:
+      - 0200
+      - \d{10}
+      - 4F2F0F90000030
+  - matches:
+      - 0201
+      - \d{10}
+      - 4F2F0F90000030
+response:
+  data: ad122e1b75356c6fdf3e9c3076a80da6


### PR DESCRIPTION
adds support for the following mapping:

```
request:
  - matches:
      - 0200
      - \d{10}
      - 4F2F0F90000030
  - matches:
      - 0201
      - \d{10}
      - 4F2F0F90000030
response:
  data: ad122e1b75356c6fdf3e9c3076a80da612
```