### PR TITLE
Upgrade h2database dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <spotify-hamcrest-optional.version>1.2.0</spotify-hamcrest-optional.version>
         <testcontainers.version>1.15.2</testcontainers.version>
+        <h2-database.version>2.0.202</h2-database.version>
         <awaitility.version>4.0.3</awaitility.version>
 
         <!-- Plugins -->
@@ -217,6 +218,11 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2-database.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>


### PR DESCRIPTION
Added h2database dependency with latest available version in order to fix security vulnerability BDSA-2018-2507 and CVE-2021-23463
